### PR TITLE
Fix API problem

### DIFF
--- a/src/main/java/me/aglerr/krakenmobcoins/api/MobCoinsAPI.java
+++ b/src/main/java/me/aglerr/krakenmobcoins/api/MobCoinsAPI.java
@@ -4,7 +4,7 @@ import me.aglerr.krakenmobcoins.MobCoins;
 import me.aglerr.krakenmobcoins.database.PlayerCoins;
 import me.aglerr.krakenmobcoins.manager.SalaryManager;
 import me.aglerr.krakenmobcoins.manager.ToggleNotificationManager;
-import org.bukkit.entity.Player;
+import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.Nullable;
 
 public class MobCoinsAPI {
@@ -15,7 +15,7 @@ public class MobCoinsAPI {
     }
 
     @Nullable
-    public PlayerCoins getPlayerData(Player player){
+    public PlayerCoins getPlayerData(OfflinePlayer player){
         return plugin.getAccountManager().getPlayerData(player.getUniqueId().toString());
     }
 


### PR DESCRIPTION
Plugins may want to retrieve the value of offline players as well as online. Using the OfflinePlayer class here should fix this issue, since the internal data storage looks players up by their UUID. Player inherits the function getUniqueId from both Entity and OfflinePlayer, but it shouldn't matter here because they return the same thing for players. If you think this change is problematic or could be done in a better way, feel free to comment.